### PR TITLE
added support to run app.js as a normal express.js server

### DIFF
--- a/app.js
+++ b/app.js
@@ -131,3 +131,10 @@ function bootController(app, file) {
 	// require(controller)(app,template);			// Include
 	
 }
+
+// allow normal node loading if appropriate
+if (!module.parent) {
+  exports.boot().listen(3000);
+  console.log("Express server %s listening on port %d", express.version, app.address().port)
+}
+


### PR DESCRIPTION
Added a conditional server start at the bottom of the app.js file that will allow people to run the application with the command: node app.js

Added bonus is that we can use the --debug command to do some hard code debug action.
